### PR TITLE
Search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,53 @@ Assume that all `curl` calls include the following:
 }
 ```
 
+3. Search through specific fields of the sources.
+    - Searches through all sources of the given project. The search is case-insensitive and looks through the
+    fields of the sources as specified by the user.
+    - Request arguments:
+        - `query`: a string passed as a query parameter, indicating the query to be searched *(Required)*
+        - `filter`: a list of fields passed as a filter parameter, indicating the fields to be searched *(Required)*
+    - Returns: A JSON object with the following keys:
+        - "success": holds `true` if the request was successful
+        - "sources": an array of `short source` objects representing all the sources in the project
+         that contain the given query in any of the fields specified
+    - Sample: `curl https://knolist-api.herokuapp.com/projects/1/sources?query=Duchess&filter=title&filter=content`
+```
+200 OK
+```
+```json
+{
+  "sources": [
+    {
+      "id": 1,
+      "next_sources": [],
+      "prev_sources": [
+        2
+      ],
+      "project_id": 1,
+      "title": "Robert Browning - Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Robert_Browning",
+      "x_position": null,
+      "y_position": null
+    },
+    {
+      "id": 2,
+      "next_sources": [
+        4,
+        1
+      ],
+      "prev_sources": [],
+      "project_id": 1,
+      "title": "My Last Duchess - Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/My_Last_Duchess",
+      "x_position": null,
+      "y_position": null
+    }
+  ],
+  "success": true
+}
+```
+
 ### POST '/projects/{project_id}/sources'
 - Creates a new source and adds it to the given project (based on the ID). The source is created based on its URL, 
 which is used to extract the page title and content, both of which are saved in the database.

--- a/app/test/test_projects.py
+++ b/app/test/test_projects.py
@@ -199,6 +199,53 @@ class TestProjectsEndpoints(unittest.TestCase):
         self.assertTrue(data['success'])
         self.assertEqual(len(data['sources']), 1)  # Only source 1
 
+    def test_single_filter_search_sources(self):
+        query = quote('Source')
+        filter = quote('title')
+        path_str = f'/projects/{self.project_1.id}/sources?query={query}&filter={filter}'
+        res = self.client().get(path_str, headers=auth_header)
+        data = json.loads(res.data)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(data['success'])
+        self.assertEqual(len(data['sources']), 2)  # All sources of project 1
+
+    def test_single_filter_search_sources_no_match(self):
+        query = quote('a')
+        filter = quote('highlights')
+        path_str = f'/projects/{self.project_1.id}/sources?query={query}&filter={filter}'
+        res = self.client().get(path_str, headers=auth_header)
+        data = json.loads(res.data)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(data['success'])
+        self.assertEqual(len(data['sources']), 0)  # None of the sources
+
+    def test_multiple_filter_search_sources(self):
+        query = quote('first')
+        filter_one = quote('content')
+        filter_two = quote('highlights')
+        path_str = f'/projects/{self.project_1.id}/sources?query={query}&filter={filter_one}&filter={filter_two}'
+        res = self.client().get(path_str, headers=auth_header)
+        data = json.loads(res.data)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(data['success'])
+        self.assertEqual(len(data['sources']), 1)  # Only source 1
+
+    def test_multiple_filter_search_sources_no_match(self):
+        query = quote('knolist')
+        filter_one = quote('url')
+        filter_two = quote('notes')
+        filter_three = quote('content')
+        path_str = f'/projects/{self.project_1.id}/sources?query={query}&filter={filter_one}&filter={filter_two}&filter={filter_three}'
+        res = self.client().get(path_str, headers=auth_header)
+        data = json.loads(res.data)
+
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(data['success'])
+        self.assertEqual(len(data['sources']), 0)  # No sources have knolist
+
     # POST '/projects/{project_id}/sources' #
     def test_create_source(self):
         old_total = len(Project.query.get(self.project_1.id).sources)


### PR DESCRIPTION
- Worked with the Sources search endpoint for now, going to adapt to Items endpoint when things are finalized by those who are working on them
- Couldn't think of many other tests using the projects/sources in the init.py file, but I did test edge cases by editing the init.py file (for example, a search involving filters 'notes' and 'title' and a query that shows up in one source's notes and another source's title should result in both sources being returned). Didn't commit those changes to init.py though so this didn't interfere with other's tests